### PR TITLE
feat: commit returns new commit hash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub fn add<P: AsRef<Path>>(repo: &str, files: &[P]) -> Result<(), Error> {
     index.write()
 }
 
-pub fn commit(repo: &str, name: &str, email: &str, message: &str) -> Result<(), Error> {
+pub fn commit(repo: &str, name: &str, email: &str, message: &str) -> Result<String, Error> {
     let signature = try!(Signature::now(name, email));
     let update_ref = Some("HEAD");
 
@@ -44,7 +44,8 @@ pub fn commit(repo: &str, name: &str, email: &str, message: &str) -> Result<(), 
     let tree_oid = try!(index.write_tree());
     let tree = try!(repo.find_tree(tree_oid));
 
-    repo
-        .commit(update_ref, &signature, &signature, message, &tree, &parents)
-        .map(|_| ())
+    match repo.commit(update_ref, &signature, &signature, message, &tree, &parents) {
+        Ok(oid) => Ok(oid.to_string()),
+        Err(err) => Err(err)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn git_add(args: &Args) -> Result<(), Error> {
     git2_commit::add(repo, files)
 }
 
-fn git_commit(args: &Args) -> Result<(), Error> {
+fn git_commit(args: &Args) -> Result<String, Error> {
     let repo = &args.flag_repository;
 
     let signature = try!(git2_commit::get_signature());
@@ -47,10 +47,13 @@ fn git_commit(args: &Args) -> Result<(), Error> {
     git2_commit::commit(repo, &signature.name, &signature.email, message)
 }
 
-fn run(args: &Args) -> Result<(), Error> {
+fn run(args: &Args) -> Result<String, Error> {
 
     if args.cmd_add {
-        return git_add(args);
+        return match git_add(args) {
+            Ok(_) => Ok(String::new()),
+            Err(err) => Err(err)
+        }
     }
 
     if args.cmd_commit {
@@ -66,7 +69,7 @@ fn main() {
         .unwrap_or_else(|e| e.exit());
 
     match run(&args) {
-        Ok(()) => {}
+        Ok(commit_id) => println!("Commit ID: {}", commit_id),
         Err(e) => println!("error: {}", e.message()),
 
     }


### PR DESCRIPTION
This PR enhances the `commit` function to return the hash of the new commit
